### PR TITLE
Enable PS/2 keyboard input via PIC IRQs

### DIFF
--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -15,7 +15,8 @@ mod pic;
 use crate::interrupts::{
     gdt::reload_gdt,
     interrupt_register::init_idt,
-    pic::{PICS, Pics},
+    pic::{InterruptIndex, PICS, Pics, enable_irq},
+    pic_handlers::enable_keyboard_irq,
 };
 
 /// Initializes the GDT, IDT and PIC controllers
@@ -23,5 +24,7 @@ pub fn setup() {
     reload_gdt();
     init_idt();
     PICS.initialize();
+    enable_irq(InterruptIndex::Timer);
+    enable_keyboard_irq();
     logln!("Interrupts set up");
 }

--- a/kernel/src/interrupts/pic.rs
+++ b/kernel/src/interrupts/pic.rs
@@ -21,6 +21,13 @@ impl InterruptIndex {
     pub fn as_u8(self) -> u8 {
         self as u8
     }
+
+    /// Translate an IDT vector back into the PIC IRQ line that raised it.
+    pub fn irq_line(self) -> u8 {
+        self.as_u8()
+            .checked_sub(PIC_1_OFFSET)
+            .expect("PIC-backed interrupts should have an IDT vector at or above PIC_1_OFFSET")
+    }
 }
 
 /// The PICs of the system.
@@ -42,5 +49,25 @@ impl Pics for OnceMutex<ChainedPics> {
 
     unsafe fn notify_end_of_interrupt(&self, interrupt_id: u8) {
         unsafe { self.lock().unwrap().notify_end_of_interrupt(interrupt_id) };
+    }
+}
+
+/// Unmask one PIC IRQ line without disturbing the rest of the mask state.
+pub fn enable_irq(interrupt: InterruptIndex) {
+    let irq_line = interrupt.irq_line();
+    let mut pics = PICS.lock().unwrap();
+
+    let [mut master_mask, mut slave_mask] = unsafe { pics.read_masks() };
+
+    if irq_line < 8 {
+        master_mask &= !(1 << irq_line);
+    } else {
+        // Unmask the IRQ on the slave PIC
+        slave_mask &= !(1 << (irq_line - 8));
+        // Ensure IRQ2 on the master PIC is unmasked for slave communication
+        master_mask &= !(1 << 2);
+    }
+    unsafe {
+        pics.write_masks(master_mask, slave_mask);
     }
 }

--- a/kernel/src/interrupts/pic_handlers/keyboard.rs
+++ b/kernel/src/interrupts/pic_handlers/keyboard.rs
@@ -6,7 +6,8 @@ use x86_64::structures::idt::InterruptStackFrame;
 
 use crate::interrupts::pic::{PICS, Pics};
 use crate::interrupts::{
-    pic::InterruptIndex, pic_handlers::addresses::PS2_INTERRUPT_CONTROLLER_SCAN_CODE_PORT,
+    pic::{InterruptIndex, enable_irq},
+    pic_handlers::addresses::PS2_INTERRUPT_CONTROLLER_SCAN_CODE_PORT,
 };
 
 lazy_static! {
@@ -16,6 +17,11 @@ lazy_static! {
             layouts::Us104Key,
             HandleControl::Ignore
         ));
+}
+
+pub fn enable_keyboard_irq() {
+    // makes IRQ1 visible to the PIC.
+    enable_irq(InterruptIndex::Keyboard);
 }
 
 /// Handles a keyboard interrupt.

--- a/kernel/src/interrupts/pic_handlers/mod.rs
+++ b/kernel/src/interrupts/pic_handlers/mod.rs
@@ -1,7 +1,7 @@
 mod timer;
 pub use timer::timer_interrupt_handler;
 mod keyboard;
-pub use keyboard::keyboard_interrupt_handler;
+pub use keyboard::{enable_keyboard_irq, keyboard_interrupt_handler};
 mod ata;
 pub use ata::{ata_primary_interrupt_handler, ata_secondary_interrupt_handler};
 mod addresses;


### PR DESCRIPTION
Unmask IRQ1 so the keyboard interrupt handler can receive inputs